### PR TITLE
Add py4u.net

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -55,6 +55,7 @@ overcoder.net
 phpancake.com
 pretagteam.com
 proubuntu.ru
+py4u.net
 qastack.ru
 qathai.com
 qenabled.com


### PR DESCRIPTION
This website has a generic Python tutorial on its homepage. All pages are littered with ads and analytics.

Evidence:
https://www.py4u.net/discuss/202716
https://stackoverflow.com/questions/202716